### PR TITLE
add GenerationOptionsOllama.num_predict to limit the number of output tokens

### DIFF
--- a/LLMlean/API.lean
+++ b/LLMlean/API.lean
@@ -29,6 +29,9 @@ deriving Inhabited, Repr
 structure GenerationOptionsOllama where
   temperature : Float := 0.3
   «stop» : List String := ["\n", "[/TAC]"]
+
+  /-- Maximum number of tokens to generate. `-1` means no limit. -/
+  num_predict : Int := 100
 deriving ToJson
 
 structure GenerationOptions where


### PR DESCRIPTION
When I try `llmqed` (with ollama and solobsd/llemma-7b) on the last step of the proof [here](https://github.com/dwrensha/compfiles/blob/199e9316fd8dab08ac60d0400c91cda85ad2a9ba/Compfiles/Imo2015P5.lean#L106) (replacing the `linarith`), it can run for a very long time without returning any results. Apparently, generation is not reaching a stopping condition.

According to https://github.com/ollama/ollama/issues/581, the `num_predict` option sets the maximum number of output tokens for a request. Indeed, when I set that parameter, `llmqed` no longer takes an unreasonable amount of time.

This PR adds an integer `num_predict` field to `GenerationOptionsOllama`, with a default value of 100, to match the default values of `TogetherAIQedRequest.max_tokens` and `TogetherAITacticGenerationRequest.max_tokens`.
