### PR TITLE
Iterative Refinement

### DIFF
--- a/LLMlean/API/Common.lean
+++ b/LLMlean/API/Common.lean
@@ -220,13 +220,21 @@ def filterGeneration (s: String) : Bool :=
   !(banned.any fun s' => (s.splitOn s').length > 1)
 
 def getNumSamples (api : API) : CoreM Nat := do
-  let apiDefaultSamples := match api.kind with
-  | APIKind.Ollama => defaultOllamaSamples
-  | _ => defaultSamples
+  -- Check if we're in iterative mode
+  let mode ← Config.getModeEnum
+  match mode with
+  | Config.GenerationMode.Iterative =>
+    -- In iterative mode, always use 1 sample
+    return 1
+  | Config.GenerationMode.Parallel =>
+    -- In parallel mode, use configured samples
+    let apiDefaultSamples := match api.kind with
+    | APIKind.Ollama => defaultOllamaSamples
+    | _ => defaultSamples
 
-  match ← Config.getNumSamples with
-  | none | some 0 => return apiDefaultSamples
-  | some n => return n
+    match ← Config.getNumSamples with
+    | none | some 0 => return apiDefaultSamples
+    | some n => return n
 
 def getMaxTokens : CoreM Nat := do
   match ← Config.getMaxTokens with

--- a/LLMlean/API/Prompts.lean
+++ b/LLMlean/API/Prompts.lean
@@ -252,4 +252,103 @@ def makeQedPrompts (promptKind : PromptKind) (context : String) (state : String)
   | PromptKind.Instruction => makeQedPromptsInstruct context state
   | PromptKind.MarkdownReasoning => makeQedPromptsMarkdownReasoning context state
 
+def makeQedRefinementPromptsFewShot (context : String) (_state : String)
+    (previousAttempt : String) (errorMsg : String) : List String :=
+  let p1 := s!"/- Previous proof attempt failed.
+Error: {errorMsg}
+
+Previous attempt:
+{previousAttempt}
+
+Please try a different approach.
+-/
+{context}"
+  [p1]
+
+def makeQedRefinementPromptsInstruct (context : String) (state : String)
+    (previousAttempt : String) (errorMsg : String) : List String :=
+  let p1 := s!"/- You are proving a theorem in Lean 4.
+Your previous proof attempt failed with the following error:
+{errorMsg}
+
+Previous attempt:
+[PROOF]
+{previousAttempt}
+[/PROOF]
+
+Please provide a corrected proof that addresses this error.
+Put the proof inside [PROOF]...[/PROOF]
+-/
+[CTX]
+{context}
+[/CTX]
+[STATE]
+{state}
+[/STATE]
+[PROOF]"
+  [p1]
+
+def makeQedRefinementPromptsReasoning (context : String) (state : String)
+    (previousAttempt : String) (errorMsg : String) : List String :=
+  let p1 := s!"/- You are proving a theorem in Lean 4.
+Your previous proof attempt failed with the following error:
+{errorMsg}
+
+Previous attempt:
+{previousAttempt}
+
+Please analyze what went wrong and provide a corrected proof.
+Put your analysis inside [THOUGHTS]...[/THOUGHTS] and the corrected proof inside [PROOF]...[/PROOF].
+Do not include any additional text outside these blocks.
+Write ONLY the proof inside of [PROOF]...[/PROOF]. For instance, do NOT write ```lean4 ... ```.
+-/
+[CTX]
+{context}
+[/CTX]
+[STATE]
+{state}
+[/STATE]
+[THOUGHTS]"
+  [p1]
+
+def makeQedRefinementPromptsMarkdownReasoning (context : String) (state : String)
+    (previousAttempt : String) (errorMsg : String) : List String :=
+  let p1 := s!"You are proving a theorem in Lean 4.
+
+Your previous proof attempt failed with the following error:
+**Error:** {errorMsg}
+
+**Previous attempt:**
+```lean4
+{previousAttempt}
+```
+
+The file contents up to the current tactic are:
+```lean4
+{context}
+```
+
+The current proof state is:
+{state}
+
+Please analyze what went wrong and provide a corrected proof.
+Write your thoughts about the error and then provide the complete corrected proof in a markdown code block.
+
+IMPORTANT: End with your corrected proof in the format:
+```lean4
+<... your corrected proof here...>
+```"
+  [p1]
+
+/--
+Make refinement prompts for proof completion with error context
+-/
+def makeQedRefinementPrompts (promptKind : PromptKind) (context : String) (state : String)
+    (previousAttempt : String) (errorMsg : String) : List String :=
+  match promptKind with
+  | PromptKind.FewShot => makeQedRefinementPromptsFewShot context state previousAttempt errorMsg
+  | PromptKind.Instruction => makeQedRefinementPromptsInstruct context state previousAttempt errorMsg
+  | PromptKind.Reasoning => makeQedRefinementPromptsReasoning context state previousAttempt errorMsg
+  | PromptKind.MarkdownReasoning => makeQedRefinementPromptsMarkdownReasoning context state previousAttempt errorMsg
+
 end LLMlean

--- a/LLMlean/API/ProofGen.lean
+++ b/LLMlean/API/ProofGen.lean
@@ -187,4 +187,26 @@ def LLMlean.Config.API.proofCompletion
     | APIKind.Anthropic =>
       qedAnthropic prompts api options
 
+/--
+Generates proof completions with refinement context using the LLM API.
+-/
+def LLMlean.Config.API.proofCompletionRefinement
+  (api : API) (tacticState : String) (context : String)
+  (previousAttempt : String) (errorMsg : String) : CoreM $ Array (String × Float) := do
+  let prompts := makeQedRefinementPrompts api.promptKind context tacticState previousAttempt errorMsg
+  let options ← getChatGenerationOptionsQed api
+  match api.kind with
+    | APIKind.Ollama =>
+      match api.responseFormat with
+      | ResponseFormat.Markdown =>
+        qedOllamaMarkdown prompts context api options
+      | _ =>
+        qedOllama prompts api options
+    | APIKind.TogetherAI =>
+      qedOpenAI prompts api options
+    | APIKind.OpenAI =>
+      qedOpenAI prompts api options
+    | APIKind.Anthropic =>
+      qedAnthropic prompts api options
+
 end LLMlean

--- a/LLMlean/IterativeRefinement.lean
+++ b/LLMlean/IterativeRefinement.lean
@@ -1,0 +1,185 @@
+import Lean
+import LLMlean.Config
+import LLMlean.API
+import LLMlean.LLMstep
+
+namespace LLMlean
+
+open Lean
+open Elab
+open Config
+
+/-!
+## Iterative Refinement for Proof Generation
+
+This module implements iterative refinement for LLM-based proof generation.
+Instead of generating multiple samples in parallel, it generates one attempt,
+analyzes any errors, and refines the proof based on the feedback.
+-/
+
+/-- Result of a proof attempt -/
+inductive ProofAttemptResult
+  | Success (proof : String)
+  | Error (attempt : String) (errorMsg : String) (goalState : String)
+  deriving Inhabited, Repr
+
+/-- Context for iterative refinement -/
+structure RefinementContext where
+  originalGoal : String
+  previousAttempts : List (String × String)  -- (attempt, error)
+  iteration : Nat
+  deriving Inhabited, Repr
+
+/-- Extract detailed error information from failed tactic evaluation -/
+structure ErrorInfo where
+  message : String
+  hasUnsolvedGoals : Bool := false
+  deriving Inhabited, Repr
+
+def extractErrorInfo (messages : MessageLog) (hasUnsolvedGoals : Bool := false) : IO ErrorInfo := do
+  let mut errorMsgs : List String := []
+  for msg in messages.toList do
+    if msg.severity == MessageSeverity.error then
+      let msgStr ← msg.data.toString
+      errorMsgs := errorMsgs.append [msgStr]
+
+  let errorMessage := if errorMsgs.isEmpty then
+    if hasUnsolvedGoals then
+      "Tactic succeeded but did not complete the proof"
+    else
+      "Unknown error"
+  else
+    String.intercalate "\n\n-----" errorMsgs
+
+  IO.println s!"errorMsgs: {errorMsgs}"
+  return {
+    message := errorMessage
+    hasUnsolvedGoals := hasUnsolvedGoals
+  }
+
+/-- Generate a single proof completion attempt -/
+def generateSingleProofAttempt (api : Config.API) (tacticState : String) (context : String) : CoreM String := do
+  -- Generate with API
+  let results ← LLMlean.Config.API.proofCompletion api tacticState context
+  if h : results.size > 0 then
+    return results[0].1
+  else
+    throwError "No response from LLM"
+
+/-- Generate a refinement proof attempt with error context -/
+def generateRefinementProofAttempt (api : Config.API) (tacticState : String) (context : String)
+    (previousAttempt : String) (errorMsg : String) : CoreM String := do
+  -- Generate with refinement API
+  let results ← LLMlean.Config.API.proofCompletionRefinement api tacticState context previousAttempt errorMsg
+  if h : results.size > 0 then
+    return results[0].1
+  else
+    throwError "No response from LLM"
+
+
+/-- Result of checking a proof with error message -/
+structure CheckResultWithError where
+  result : CheckResult
+  errorMsg : String := ""
+
+/-- Check if a proof completion is valid and get error messages -/
+def checkProofCompletion (proof : String) : Elab.Tactic.TacticM CheckResultWithError := do
+  let (result, messages) ← withoutModifyingState do
+    try
+      -- Same validation as in LLMqed
+      let s' := "(" ++ (proof.replace "\n" "\n ") ++ " )"
+      match Parser.runParserCategory (← getEnv) `tactic s' with
+        | Except.ok stx =>
+          try
+            _ ← Elab.Tactic.evalTactic stx
+            let goals ← Elab.Tactic.getUnsolvedGoals
+            let messages := (← getThe Core.State).messages
+            if messages.hasErrors then
+              pure (CheckResult.Invalid, messages)
+            else if goals.isEmpty then
+              pure (CheckResult.ProofDone, messages)
+            else
+              pure (CheckResult.Valid, messages)
+          catch e =>
+            let messages := (← getThe Core.State).messages
+            pure (CheckResult.Invalid, messages)
+        | Except.error parseError =>
+          pure (CheckResult.Invalid, MessageLog.empty.add {
+            fileName := ""
+            pos := ⟨0, 0⟩
+            severity := MessageSeverity.error
+            data := parseError
+          })
+      catch e =>
+        pure (CheckResult.Invalid, MessageLog.empty.add {
+          fileName := ""
+          pos := ⟨0, 0⟩
+          severity := MessageSeverity.error
+          data := e.toMessageData
+        })
+
+  -- Extract error message if invalid
+  let errorMsg ← if result == CheckResult.Invalid then
+    let errorInfo ← extractErrorInfo messages false
+    pure errorInfo.message
+  else if result == CheckResult.Valid then
+    pure "Tactic valid but proof incomplete"
+  else
+    pure ""
+
+  return { result := result, errorMsg := errorMsg }
+
+/-- Main iterative refinement loop for proof completion -/
+def iterativeRefinementProofInTactic (tacticState : String) (context : String)
+    (api : Config.API) (maxIterations : Nat) : Elab.Tactic.TacticM (List String) := do
+  IO.println s!"[Iterative Refinement] Starting with max iterations: {maxIterations}"
+  IO.println s!"[Iterative Refinement] Original goal: {tacticState}"
+
+  let mut ctx : RefinementContext := {
+    originalGoal := tacticState
+    previousAttempts := []
+    iteration := 0
+  }
+
+  let mut validProofs : List String := []
+
+  for i in [0:maxIterations] do
+    ctx := { ctx with iteration := i }
+    IO.println s!"\n[Iterative Refinement] === Iteration {i + 1}/{maxIterations} ==="
+
+    -- Generate attempt based on iteration
+    let proof ← if i == 0 then
+      -- First attempt: use normal API
+      IO.println s!"[Iterative Refinement] Calling LLM (first attempt)..."
+      generateSingleProofAttempt api tacticState context
+    else
+      -- Refinement: use dedicated refinement API
+      let (lastAttempt, lastError) := ctx.previousAttempts.head!
+      IO.println s!"[Iterative Refinement] Previous attempt:\n{lastAttempt}"
+      IO.println s!"[Iterative Refinement] Error: {lastError}"
+      IO.println s!"[Iterative Refinement] Calling LLM with refinement context..."
+      generateRefinementProofAttempt api tacticState context lastAttempt lastError
+
+    IO.println s!"[Iterative Refinement] LLM response:\n{proof}"
+
+    -- Check if the proof is valid
+    let checkResult ← checkProofCompletion proof
+    match checkResult.result with
+    | CheckResult.ProofDone =>
+      IO.println s!"[Iterative Refinement] ✓ Proof complete!"
+      validProofs := validProofs ++ [proof]
+      break
+    | CheckResult.Valid =>
+      IO.println s!"[Iterative Refinement] ⚠ Valid tactic but proof not complete, continuing..."
+      IO.println s!"[Iterative Refinement] Reason: {checkResult.errorMsg}"
+      ctx := { ctx with previousAttempts := (proof, checkResult.errorMsg) :: ctx.previousAttempts }
+    | CheckResult.Invalid =>
+      IO.println s!"[Iterative Refinement] ✗ Invalid proof, continuing..."
+      IO.println s!"[Iterative Refinement] Error: {checkResult.errorMsg}"
+      ctx := { ctx with previousAttempts := (proof, checkResult.errorMsg) :: ctx.previousAttempts }
+
+  IO.println s!"[Iterative Refinement] Completed. Generated {validProofs.length} valid proof(s)."
+  return validProofs
+
+
+end LLMlean

--- a/LLMlean/LLMqed.lean
+++ b/LLMlean/LLMqed.lean
@@ -121,26 +121,26 @@ elab_rules : tactic
       -- Check which mode to use
       let mode ← Config.getModeEnum
       let modeStr ← Config.getMode
-      IO.println s!"[LLMqed] Using mode: {modeStr}"
+      Config.verbosePrint s!"Using mode: {modeStr}"
       let suggestions ← match mode with
       | Config.GenerationMode.Iterative =>
-        IO.println s!"[LLMqed] Starting iterative refinement..."
+        Config.verbosePrint s!"Starting iterative refinement..."
         -- Use iterative refinement
         llmQedIterative ctx (← getMainGoal)
       | Config.GenerationMode.Parallel =>
-        IO.println s!"[LLMqed] Using parallel generation..."
+        Config.verbosePrint s!"Using parallel generation..."
         -- Use parallel generation
         liftMetaMAtMain (llmQed ctx)
       addSuggestions' tac suggestions
     | none =>
       let mode ← Config.getModeEnum
       let modeStr ← Config.getMode
-      IO.println s!"[LLMqed] Using mode: {modeStr} (no context)"
+      Config.verbosePrint s!"Using mode: {modeStr} (no context)"
       let suggestions ← match mode with
       | Config.GenerationMode.Iterative =>
-        IO.println s!"[LLMqed] Starting iterative refinement..."
+        Config.verbosePrint s!"Starting iterative refinement..."
         llmQedIterative "" (← getMainGoal)
       | Config.GenerationMode.Parallel =>
-        IO.println s!"[LLMqed] Using parallel generation..."
+        Config.verbosePrint s!"Using parallel generation..."
         liftMetaMAtMain (llmQed "")
       addSuggestions' tac suggestions

--- a/LLMlean/LLMqed.lean
+++ b/LLMlean/LLMqed.lean
@@ -6,6 +6,7 @@ import Lean.Meta.Tactic.TryThis
 
 import LLMlean.API
 import LLMlean.LLMstep
+import LLMlean.IterativeRefinement
 
 open Lean LLMlean
 
@@ -96,6 +97,17 @@ def llmQed (ctx : String) (g : MVarId) : MetaM (Array (String × Float)) := do
   let pp := toString (← Meta.ppGoal g)
   runTactic pp ctx
 
+/--
+Call the LLM on a goal using iterative refinement for proof completion.
+-/
+def llmQedIterative (ctx : String) (g : MVarId) : Elab.Tactic.TacticM (Array (String × Float)) := do
+  let pp := toString (← Meta.ppGoal g)
+  let api ← getConfiguredAPI
+  let maxIterations ← Config.getMaxIterations
+  let suggestions ← iterativeRefinementProofInTactic pp ctx api maxIterations
+  -- Convert to array with dummy scores
+  return suggestions.toArray.map (·, 1.0)
+
 open Lean Elab Tactic
 
 /- `llmqed` tactic. -/
@@ -106,6 +118,29 @@ elab_rules : tactic
     | some range =>
       let src := (← getFileMap).source
       let ctx := src.extract src.toSubstring.startPos range.start
-      addSuggestions' tac (← liftMetaMAtMain (llmQed ctx))
+      -- Check which mode to use
+      let mode ← Config.getModeEnum
+      let modeStr ← Config.getMode
+      IO.println s!"[LLMqed] Using mode: {modeStr}"
+      let suggestions ← match mode with
+      | Config.GenerationMode.Iterative =>
+        IO.println s!"[LLMqed] Starting iterative refinement..."
+        -- Use iterative refinement
+        llmQedIterative ctx (← getMainGoal)
+      | Config.GenerationMode.Parallel =>
+        IO.println s!"[LLMqed] Using parallel generation..."
+        -- Use parallel generation
+        liftMetaMAtMain (llmQed ctx)
+      addSuggestions' tac suggestions
     | none =>
-      addSuggestions' tac (← liftMetaMAtMain (llmQed ""))
+      let mode ← Config.getModeEnum
+      let modeStr ← Config.getMode
+      IO.println s!"[LLMqed] Using mode: {modeStr} (no context)"
+      let suggestions ← match mode with
+      | Config.GenerationMode.Iterative =>
+        IO.println s!"[LLMqed] Starting iterative refinement..."
+        llmQedIterative "" (← getMainGoal)
+      | Config.GenerationMode.Parallel =>
+        IO.println s!"[LLMqed] Using parallel generation..."
+        liftMetaMAtMain (llmQed "")
+      addSuggestions' tac suggestions

--- a/LLMlean/LLMstep.lean
+++ b/LLMlean/LLMstep.lean
@@ -20,6 +20,7 @@ def runSuggest (goal pre ctx: String) (api : Option Config.API := none) :
     | some api => pure api
     -- if the API is provided, use the one found in the configuration.
     | none => getConfiguredAPI
+  
   let s ← api.tacticGeneration goal ctx pre
   return s
 
@@ -70,7 +71,7 @@ inductive CheckResult : Type
   | ProofDone
   | Valid
   | Invalid
-  deriving ToJson, Ord
+  deriving ToJson, Ord, BEq
 
 /- Check whether the suggestion `s` completes the proof, is valid (does
 not result in an error message), or is invalid. -/
@@ -145,6 +146,7 @@ Call the LLM on a goal, asking for suggestions beginning with a prefix.
 def llmStep (pre : String) (ctx : String) (g : MVarId) : MetaM (Array (String × Float)) := do
   let pp := toString (← Meta.ppGoal g)
   runSuggest pp pre ctx
+
 
 open Lean Elab Tactic
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ LLMlean integrates LLMs and Lean for tactic suggestions, proof completion, and m
 
 ## News
 
+- **06/2025**: Introduced iterative refinement mode for proof generation
 - **06/2025**: Added support for [Kimina Prover](https://arxiv.org/abs/2504.11354) models via Ollama (thanks to @BoltonBailey)
 
 Here's an example of using LLMLean on problems from [Mathematics in Lean](https://github.com/leanprover-community/mathematics_in_lean):
@@ -84,7 +85,24 @@ Complete the current proof via `llmqed`. Examples:
 
 The suggestions are checked in Lean.
 
-*For the best performance, especially for the `llmqed` tactic, we recommend using the Open AI API.*
+### Proof Generation Modes
+
+LLMLean supports two modes for proof generation with `llmqed`:
+- **Parallel mode**: Generates multiple proof attempts in parallel
+- **Iterative refinement mode**: Generates one proof attempt, analyzes any errors, and refines the proof based on feedback
+
+To configure:
+```toml
+# In ~/.config/llmlean/config.toml
+mode = "iterative"  # or "parallel"
+```
+
+Enable verbose output to see the refinement process:
+```lean
+set_option llmlean.verbose true
+```
+
+*For the best performance, especially for the `llmqed` tactic, we recommend using Anthropic Claude with iterative refinement mode.*
 
 
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -22,8 +22,17 @@ Example:
   - Example for Anthropic: `claude-3-7-sonnet-20250219`
 - `numSamples`:
   - Example: `10`
+- `mode`:
+  - `parallel`: Generate multiple proof attempts in parallel
+  - `iterative`: Generate and refine proofs based on error feedback
+- `maxIterations`:
+  - Number of refinement iterations in iterative mode (e.g., `3`)
+- `verbose`:
+  - `true`: Show detailed LLM interaction and refinement steps
 
-Set each variable in the configuration file, as indicated in [README](../README.md). Alternatively, set environment variables `LLMLEAN_API`, `LLMLEAN_API_KEY`, `LLMLEAN_ENDPOINT`, `LLMLEAN_PROMPT`, `LLMLEAN_MODEL`, and `LLMLEAN_NUM_SAMPLES` respectively, or enter `set_option llmlean.<relevant-config> <value>` before `llmstep`/`llmqed` is called.
+Set each variable in the configuration file, as indicated in [README](../README.md). Alternatively, set environment variables `LLMLEAN_API`, `LLMLEAN_API_KEY`, `LLMLEAN_ENDPOINT`, `LLMLEAN_PROMPT`, `LLMLEAN_MODEL`, `LLMLEAN_NUM_SAMPLES`, `LLMLEAN_MODE`, `LLMLEAN_MAX_ITERATIONS`, and `LLMLEAN_VERBOSE` respectively, or enter `set_option llmlean.<relevant-config> <value>` before `llmstep`/`llmqed` is called.
+
+**Note on Iterative Refinement**: This mode works particularly well with models that can understand and learn from error messages. We recommend using instruction-tuned models with the `reasoning` prompt type for best results.
 
 #### LLM on your laptop
 - `api`:


### PR DESCRIPTION
Iterative refinement mode for proof generation
  - Configurable via `mode = "iterative"` and `maxIterations`
  - Verbose output with `verbose` option
  - Documentation explaining the feature
  
  Example trace:
  
  ```
  [llmlean] Using mode: iterative 
[llmlean] Starting iterative refinement... 
[llmlean] Starting with max iterations: 3 
[llmlean] Original goal: Ω : Type u_1
    inst✝ : Fintype Ω
    p q : pmf Ω
    h : ∀ (x : Ω), p.f x = q.f x
    ⊢ p = q 
[llmlean] 
    === Iteration 1/3 === 
[llmlean] Calling LLM (first attempt)... 
[llmlean] LLM response:
    cases p
    cases q
    simp only [mk.injEq]
    exact h 
[llmlean] ✗ Invalid proof, continuing... 
[llmlean] Error: simp made no progress 
[llmlean] 
    === Iteration 2/3 === 
[llmlean] Previous attempt:
    cases p
    cases q
    simp only [mk.injEq]
    exact h 
[llmlean] Error: simp made no progress 
[llmlean] Calling LLM with refinement context... 
[llmlean] LLM response:
    cases p
    cases q
    congr
    funext x
    exact h x 
[llmlean] ✓ Proof complete! 
[llmlean] Completed. Generated 1 valid proof(s).
```