### PR TITLE
Manage defaults for different providers and tactics

### DIFF
--- a/LLMlean/API/ProofGen.lean
+++ b/LLMlean/API/ProofGen.lean
@@ -172,7 +172,7 @@ Generates proof completions using the LLM API.
 def LLMlean.Config.API.proofCompletion
   (api : API) (tacticState : String) (context : String) : CoreM $ Array (String × Float) := do
   let prompts := makeQedPrompts api.promptKind context tacticState
-  let options ← getChatGenerationOptionsQed api
+  let options ← getChatGenerationOptionsQed api TacticKind.LLMQed
   match api.kind with
     | APIKind.Ollama =>
       match api.responseFormat with
@@ -194,7 +194,7 @@ def LLMlean.Config.API.proofCompletionRefinement
   (api : API) (tacticState : String) (context : String)
   (previousAttempt : String) (errorMsg : String) : CoreM $ Array (String × Float) := do
   let prompts := makeQedRefinementPrompts api.promptKind context tacticState previousAttempt errorMsg
-  let options ← getChatGenerationOptionsQed api
+  let options ← getChatGenerationOptionsQed api TacticKind.LLMQed
   match api.kind with
     | APIKind.Ollama =>
       match api.responseFormat with

--- a/LLMlean/API/TacticGen.lean
+++ b/LLMlean/API/TacticGen.lean
@@ -172,7 +172,7 @@ def LLMlean.Config.API.tacticGeneration
   (api : API) (tacticState : String) (context : String)
   («prefix» : String) : CoreM $ Array (String × Float) := do
   let prompts := makePrompts api.promptKind context tacticState «prefix»
-  let options ← getChatGenerationOptions api
+  let options ← getChatGenerationOptions api TacticKind.LLMStep
   match api.kind with
     | APIKind.Ollama =>
       match api.responseFormat with

--- a/LLMlean/LLMqed.lean
+++ b/LLMlean/LLMqed.lean
@@ -12,7 +12,7 @@ open Lean LLMlean
 
 /- Calls an LLM API with the given context, prefix and pretty-printed goal. -/
 def runTactic (goal ctx : String) : CoreM (Array (String × Float)) := do
-  let api ← getConfiguredAPI
+  let api ← getConfiguredAPI Config.TacticKind.LLMQed
   let s ← api.proofCompletion goal ctx
   return s
 
@@ -102,7 +102,7 @@ Call the LLM on a goal using iterative refinement for proof completion.
 -/
 def llmQedIterative (ctx : String) (g : MVarId) : Elab.Tactic.TacticM (Array (String × Float)) := do
   let pp := toString (← Meta.ppGoal g)
-  let api ← getConfiguredAPI
+  let api ← getConfiguredAPI Config.TacticKind.LLMQed
   let maxIterations ← Config.getMaxIterations
   let suggestions ← iterativeRefinementProofInTactic pp ctx api maxIterations
   -- Convert to array with dummy scores

--- a/LLMlean/LLMstep.lean
+++ b/LLMlean/LLMstep.lean
@@ -19,7 +19,7 @@ def runSuggest (goal pre ctx: String) (api : Option Config.API := none) :
   let api : Config.API ← match api with
     | some api => pure api
     -- if the API is provided, use the one found in the configuration.
-    | none => getConfiguredAPI
+    | none => getConfiguredAPI Config.TacticKind.LLMStep
   
   let s ← api.tacticGeneration goal ctx pre
   return s


### PR DESCRIPTION
This PR refactors the default configuration system to provide defaults based on both the API being used and the tactic context (llmstep vs llmqed).

Changes

  1. Moved defaults from Common.lean to Config.lean to centralize all default values.
  2. Added TacticKind enumeration to distinguish between tactic configurations
  3. Implemented getDefaultsForAPI function - returns appropriate defaults based on both API and tactic
  4. Simplified API configuration - replaced multiple getConfigured*API functions with a single getConfiguredAPI that
   takes a TacticKind parameter.
  5. Added verbose logging - when `verbose` mode is enabled, prints the actual configuration values being used for each
   LLM call.